### PR TITLE
non-integer-division-error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = coguard-cli
-version = 0.1.15
+version = 0.1.16
 author = Heinle Solutions Inc.
 author_email = albert@coguard.io
 description = A command line interface for scanning configuration files with CoGuard

--- a/src/coguard_cli/__init__.py
+++ b/src/coguard_cli/__init__.py
@@ -35,7 +35,7 @@ def print_failed_check(color: str, entry: Dict):
         terminal_size = 80
     wrapper = textwrap.TextWrapper(
         initial_indent=prefix,
-        width=max(80, terminal_size/2),
+        width=max(80, terminal_size//2),
         subsequent_indent=' '*len(prefix)
     )
     print(wrapper.fill(entry["rule"]["documentation"]))


### PR DESCRIPTION
Well, that is embarrassing... Forgot that `/` is not doing integer
division on two integers, but converts them into a float.

That has caused an output error on some versions of python and some
terminals