### PR TITLE
COS-298 - Fix `dot` path.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = coguard-cli
-version = 0.2.2
+version = 0.2.3
 author = Heinle Solutions Inc.
 author_email = albert@coguard.io
 description = A command line interface for scanning configuration files with CoGuard

--- a/src/coguard_cli/__init__.py
+++ b/src/coguard_cli/__init__.py
@@ -469,8 +469,12 @@ OXXo  ;XXO     do     KXX.     cXXXX.   .XXXXXXXXo oXXXX        XXXXc  ;XXXX    
             args.fail_level
         )
     elif args.subparsers_location == SubParserNames.FOLDER_SCAN.value:
-        folder_name = args.folder_name or args.scan or None # args.scan is a trick to
-                                                            # think there is a positional argument
+        folder_name = args.folder_name or \
+            args.scan or \
+            None # args.scan is a trick to
+                 # think there is a positional argument
+        if folder_name is not None:
+            folder_name = os.path.abspath(folder_name)
         perform_folder_scan(
             folder_name,
             deal_type,


### PR DESCRIPTION
It appears that the cli does not work well when puttint in a . path. This change fixes it.