### PR TITLE
COS-417 - Avoid gcp bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ sudo pacman -S python python-pip
 
 <details>
 <summary>Mac OS</summary>
-<a id="macos-install"></a>Using <a href="https://brew.sh">Homebrew</a>, run the following:
+Assuming you are using [Homebrew](https://brew.sh), you have to run
 
 ```shell
 brew install python3
@@ -141,7 +141,7 @@ brew install python3
 <details>
 <summary>Windows</summary>
 
-<a id="windows-install"></a>Download Python3 for Windows using [this link](https://www.python.org/downloads/windows/), and
+Download Python3 for Windows using [this link](https://www.python.org/downloads/windows/), and
 install it.
 
 </details>
@@ -155,7 +155,7 @@ directly, or installed via `pip`:
 pip3 install coguard-cli
 ```
 
-_Reminder_: It is a requirement to have [Docker](https://docker.com) installed and running locally.
+This is a reminder that it is a requirement to have [Docker[(https://docker.com) installed locally.
 
 
 ### <a id="installation-remarks"></a>Installation remarks
@@ -329,4 +329,4 @@ configuration files in the near future.
 
 - [CoGuard](https://www.coguard.io)
 - [Blog](https://www.coguard.io/blog)
-- [Contact Us](https://coguard.io/contact)
+- [Contact Us](https://coguard.io/contact

--- a/src/coguard_cli/discovery/cloud_discovery/terraformer_extract_image_helper/Dockerfile
+++ b/src/coguard_cli/discovery/cloud_discovery/terraformer_extract_image_helper/Dockerfile
@@ -35,8 +35,6 @@ RUN dnf install -y azure-cli
 
 # Install Terraformer
 
-# Using an older version until https://github.com/GoogleCloudPlatform/terraformer/issues/1648 is fixed.
-# Do not use 0.8.22
 ENV CURRENT_TERRAFORMER_VERSION=0.8.24
 # For now, we assume the provider to be AWS only; we would need to
 # check for adjustments for other providers, and maybe need to create

--- a/src/coguard_cli/discovery/cloud_discovery/terraformer_extract_image_helper/data/versions.tf
+++ b/src/coguard_cli/discovery/cloud_discovery/terraformer_extract_image_helper/data/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      # This is a temporary fixing of the version, until https://github.com/GoogleCloudPlatform/terraformer/issues/1695 is fixed
       version = "4.59.0"
     }
     aws = {


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/terraformer/issues/1695 states that any version of the GCP provider after 4.60.0 is having an issue. Fixing the version for now.