### PR TITLE
COS-441 - Cloud provider AWS scan

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = coguard-cli
-version = 0.2.28
+version = 0.2.29
 author = Heinle Solutions Inc.
 author_email = albert@coguard.io
 description = A command line interface for scanning configuration files with CoGuard

--- a/src/coguard_cli/discovery/cloud_discovery/cloud_providers/cloud_provider_aws.py
+++ b/src/coguard_cli/discovery/cloud_discovery/cloud_providers/cloud_provider_aws.py
@@ -63,8 +63,10 @@ class CloudProviderAWS(CloudProvider):
         profiles = session.available_profiles
         try:
             if len(profiles) == 0:
-                logging.error("No profiles found.")
-                return None
+                logging.info("No profiles found.")
+                credentials = session.get_credentials()
+                if not credentials:
+                    return None
             if len(profiles) == 1:
                 credentials = session.get_credentials()
             else:


### PR DESCRIPTION
It appears that when we read credentials from environment variables, there are no profiles.