### PR TITLE
COS-489 - Fix Kubernetes strict-ness

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = coguard-cli
-version = 0.2.39
+version = 0.2.40
 author = Heinle Solutions Inc.
 author_email = albert@coguard.io
 description = A command line interface for scanning configuration files with CoGuard

--- a/src/coguard_cli/discovery/config_file_finders/config_file_finder_kubernetes.py
+++ b/src/coguard_cli/discovery/config_file_finders/config_file_finder_kubernetes.py
@@ -36,8 +36,7 @@ class ConfigFileFinderKubernetes(ConfigFileFinder):
         required_fields = [
             "apiVersion",
             "kind",
-            "metadata",
-            "spec"
+            "metadata"
         ]
         logging.debug("Trying to find the file by searching"
                       " for the standard name in the filesystem.")


### PR DESCRIPTION
We noticed that, besides it being the in the documentation, the `spec` key is not always present.